### PR TITLE
Register the bandit marker with pytest

### DIFF
--- a/pytest_bandit/controller.py
+++ b/pytest_bandit/controller.py
@@ -15,10 +15,11 @@ LOG.setLevel(logging.INFO)
 
 class BanditItem(pytest.Item):
     CACHE_KEY = 'bandit/mtimes'
+    MARKER = 'bandit'
 
     def __init__(self, session):
         super().__init__('bandit', session)
-        self.add_marker('bandit')
+        self.add_marker(self.MARKER)
         self.config = session.config
 
     def setup(self):

--- a/pytest_bandit/plugin.py
+++ b/pytest_bandit/plugin.py
@@ -121,6 +121,16 @@ def pytest_addoption(parser):
     )
 
 
+def pytest_configure(config):
+    """Register a custom marker for BanditItems."""
+    config.addinivalue_line(
+        'markers',
+        '{marker}: mark tests to be checked by bandit.'.format(
+            marker=BanditItem.MARKER,
+        ),
+    )
+
+
 try:
     from StringIO import StringIO
 except ImportError:

--- a/tests/test_bandit.py
+++ b/tests/test_bandit.py
@@ -8,7 +8,8 @@ def test_help_message(testdir):
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
         'bandit:',
-        '*bandit_targets*Path to analyzed code*',
+        '*bandit_targets*',
+        '*Path to analyzed code*',
     ])
 
 


### PR DESCRIPTION
Hey there 👋  I like and use this plugin. Thanks for maintaining it!
I encountered this while using `pytest-bandit`:
> Unknown pytest.mark.bandit - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

We encountered a similar issue with `pytest-mypy` recently: https://github.com/dbader/pytest-mypy/issues/25
As the error says, the solution is to register the marker: https://docs.pytest.org/en/latest/writing_plugins.html#registering-markers