### PR TITLE
Get tests working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,11 @@ matrix:
         env: TOX_ENV=py36
       - python: 3.7
         env: TOX_ENV=py37
-      - python: 3.6
+      - python: 3.8
+        env: TOX_ENV=py38
+      - python: 3.9
+        env: TOX_ENV=py39
+      - python: 3.9
         env: TOX_ENV=flake8
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -47,10 +47,22 @@ Usage
 * add `bandit_targets` to your pytest configuration and add at least one directory to traverse
 * you probably want `bandit_recurse = true` in your configuration as well
 
+
+
 Contributing
 ------------
 Contributions are very welcome. Tests can be run with `tox`_, please ensure
 the coverage at least stays the same before you submit a pull request.
+
+
+Development setup & testing
+***************************
+
+    python -m venv .venv
+    source .venv/bin/activate
+    pip insatll tox
+    tox
+
 
 License
 -------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,15 @@ environment:
     - PYTHON: "C:\\Python36"
       TOX_ENV: "py36"
 
+    - PYTHON: "C:\\Python37"
+      TOX_ENV: "py37"
+
+    - PYTHON: "C:\\Python38"
+      TOX_ENV: "py38"
+
+    - PYTHON: "C:\\Python39"
+      TOX_ENV: "py39"
+
 init:
   - "%PYTHON%/python -V"
   - "%PYTHON%/python -c \"import struct;print( 8 * struct.calcsize(\'P\'))\""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --bandit --codestyle --cov=pytest_bandit --cov-report=xml --cov-report=term
+addopts = --bandit --pycodestyle --cov=pytest_bandit --cov-report=xml --cov-report=term
 
 codestyle_max_line_length = 120
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py35,py36,py37,flake8
+envlist = py35,py36,py37,py38,py39,flake8
 
 [testenv]
 deps = 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py35,py36,py37,flake8
 [testenv]
 deps = 
     pytest>=3.0
-    pytest-pycodestyle>=1.2.2
+    pytest-pycodestyle>=2.0.0
     pytest-cov>=2.5.1
 commands = pytest {posargs:tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py35,py36,py37,flake8
 
 [testenv]
 deps = 
-    pytest>=3.0
+    pytest>=3.0,<6.0
     pytest-pycodestyle>=2.0.0
     pytest-cov>=2.5.1
 commands = pytest {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ commands = pytest {posargs:tests}
 [testenv:flake8]
 skip_install = true
 deps = flake8
-commands = flake8 pytest_bandit.py setup.py tests
+commands = flake8 pytest_bandit setup.py tests


### PR DESCRIPTION
Fixes the following:
- Use correct pytest option for latest version of `pytest-pycodestyle`
- Corrects invocation of flake8 in `tox.ini`
- Limits tests to known working versions or `pytest`

Adds the following:
- Extends tests to newer python versions
- Small additional docs to help contributors