### PR TITLE
feat: [#7] Added format specification from config file

### DIFF
--- a/pytest_bandit/controller.py
+++ b/pytest_bandit/controller.py
@@ -70,11 +70,18 @@ class BanditItem(pytest.Item):
         sys.stdout = sys.__stdout__
         # pytest doesn't terminate the last line before invoking `runtest`
         sys.stdout.write(os.linesep)
-        b_mgr.output_results(self.config.getini('bandit_context_lines'),
-                             sev_level,
-                             conf_level,
-                             sys.stdout,
-                             'screen')
+
+        outputs = zip(
+            list(self.config.getini('bandit_output_formats')),
+            list(self.config.getini('bandit_output_files')))
+
+        for (o_fmt, o_file) in outputs:
+            o_file = open(o_file, 'w') if o_file != "screen" else sys.stdout
+            b_mgr.output_results(self.config.getini('bandit_context_lines'),
+                                 sev_level,
+                                 conf_level,
+                                 o_file,
+                                 o_fmt)
 
         # return an exit code of 1 if there are results, 0 otherwise
         LOG.debug(sev_level)

--- a/pytest_bandit/plugin.py
+++ b/pytest_bandit/plugin.py
@@ -88,10 +88,17 @@ def pytest_addoption(parser):
         )
     )
     parser.addini(
-        'bandit_output_format',
+        'bandit_output_formats',
         type='args',
-        default='screen',
-        help='(CURRENTLY NOT IMPLEMENTED) Specify output format'
+        default=('screen',),
+        help='Specify output formats'
+    )
+    parser.addini(
+        'bandit_output_files',
+        type='args',
+        default=('screen',),
+        help=('Specify output files. Must be a file for each specified format'
+              'in the same order.')
     )
     parser.addini(
         'bandit_msg_template',


### PR DESCRIPTION
Supports multiple formats.
Requires formats and files to be specified as a list (respecting the same order), i.e ::

    bandit_output_formats = ["xml", "screen"]
    bandit_output_files = "docs/source/bandit_results.xml"